### PR TITLE
Add declarative decorators to CRUDView subclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea

--- a/flask_crud/test/app/__init__.py
+++ b/flask_crud/test/app/__init__.py
@@ -62,6 +62,13 @@ class PetCollection(CollectionView):
     create_enabled = True
     list_enabled = True
 
+    _decorators = dict(
+        post=[
+            pet_blp.arguments(PetSchema),
+            pet_blp.response(PetSchema),
+        ],
+    )
+
     @pet_blp.response(PetSchemaLite(many=True))
     def get(self):
         query = super().get()
@@ -73,11 +80,6 @@ class PetCollection(CollectionView):
 
         return query
 
-    @pet_blp.arguments(PetSchema)
-    @pet_blp.response(PetSchema)
-    def post(self, args):
-        return super().post(args)
-
 
 @pet_blp.route("/<int:pk>")
 class PetResource(ResourceView):
@@ -87,18 +89,15 @@ class PetResource(ResourceView):
     update_enabled = True
     delete_enabled = True
 
-    @pet_blp.response(PetSchema)
-    def get(self, pk):
-        return super().get(pk)
-
-    @pet_blp.arguments(PetSchema)
-    @pet_blp.response(PetSchema)
-    def patch(self, args, pk):
-        return super().patch(args, pk)
-
-    @pet_blp.response(PetSchema)
-    def delete(self, pk):
-        return super().delete(pk)
+    # get_decorators = [pet_blp.response(PetSchema)]
+    _decorators = dict(
+        get=[pet_blp.response(PetSchema)],
+        patch=[
+            pet_blp.arguments(PetSchema),
+            pet_blp.response(PetSchema),
+        ],
+        delete=[pet_blp.response(PetSchema)],
+    )
 
 
 human_blp = Blueprint("humans", "humans", url_prefix="/human")
@@ -113,9 +112,9 @@ class HumanCollection(CollectionView):
 class HumanResource(ResourceView):
     model = Human
 
-    @human_blp.response(HumanSchema)
-    def get(self, pk):
-        return super().get(pk)
+    _decorators = dict(
+        get=[human_blp.response(HumanSchema)],
+    )
 
 
 pointless_blp = Blueprint(

--- a/flask_crud/test/app/__init__.py
+++ b/flask_crud/test/app/__init__.py
@@ -62,7 +62,7 @@ class PetCollection(CollectionView):
     create_enabled = True
     list_enabled = True
 
-    _decorators = dict(
+    crud_decorators = dict(
         post=[
             pet_blp.arguments(PetSchema),
             pet_blp.response(PetSchema),
@@ -90,7 +90,7 @@ class PetResource(ResourceView):
     delete_enabled = True
 
     # get_decorators = [pet_blp.response(PetSchema)]
-    _decorators = dict(
+    crud_decorators = dict(
         get=[pet_blp.response(PetSchema)],
         patch=[
             pet_blp.arguments(PetSchema),
@@ -112,7 +112,7 @@ class HumanCollection(CollectionView):
 class HumanResource(ResourceView):
     model = Human
 
-    _decorators = dict(
+    crud_decorators = dict(
         get=[human_blp.response(HumanSchema)],
     )
 

--- a/flask_crud/view.py
+++ b/flask_crud/view.py
@@ -1,4 +1,4 @@
-from typing import Iterable
+from typing import Iterable, Dict, Callable, Collection
 from flask.views import MethodView
 from flask_rest_api import abort
 from flask_sqlalchemy import BaseQuery, Model, SQLAlchemy
@@ -12,6 +12,17 @@ class CRUDView(MethodView):
 
     # define these, please
     model: Model
+
+    _decorators: Dict[str, Collection[Callable]] = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        for method_name, decorators in cls._decorators.items():
+            if not hasattr(cls, method_name):
+                continue
+            for decorator in decorators:
+                method = getattr(cls, method_name)
+                setattr(cls, method_name, decorator(method))
 
     def query(self) -> BaseQuery:
         return self._get_model().query

--- a/flask_crud/view.py
+++ b/flask_crud/view.py
@@ -13,11 +13,11 @@ class CRUDView(MethodView):
     # define these, please
     model: Model
 
-    _decorators: Dict[str, Collection[Callable]] = {}
+    crud_decorators: Dict[str, Collection[Callable]] = {}
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        for method_name, decorators in cls._decorators.items():
+        for method_name, decorators in cls.crud_decorators.items():
             if not hasattr(cls, method_name):
                 continue
             for decorator in decorators:

--- a/flask_crud/view.py
+++ b/flask_crud/view.py
@@ -1,9 +1,11 @@
-from typing import Iterable, Dict, Callable, Collection
+from functools import reduce
+from typing import Iterable, Dict, Callable, Sequence
+
 from flask.views import MethodView
 from flask_rest_api import abort
 from flask_sqlalchemy import BaseQuery, Model, SQLAlchemy
 from sqlalchemy.orm import RelationshipProperty, joinedload
-from functools import reduce
+
 from flask_crud import _crud
 
 
@@ -13,14 +15,14 @@ class CRUDView(MethodView):
     # define these, please
     model: Model
 
-    crud_decorators: Dict[str, Collection[Callable]] = {}
+    crud_decorators: Dict[str, Sequence[Callable]] = {}
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         for method_name, decorators in cls.crud_decorators.items():
             if not hasattr(cls, method_name):
                 continue
-            for decorator in decorators:
+            for decorator in reversed(decorators):
                 method = getattr(cls, method_name)
                 setattr(cls, method_name, decorator(method))
 


### PR DESCRIPTION
Removes the need for empty boilerplate methods:
```python
@pet_blp.route("/<int:pk>")
class PetResource(ResourceView):
   model = Pet

   get_enabled = True  # enabled by default
   update_enabled = True
   delete_enabled = True

   _decorators = dict(
       get=[pet_blp.response(PetSchema)],
       patch=[
           pet_blp.arguments(PetSchema),
           pet_blp.response(PetSchema),
       ],
       delete=[pet_blp.response(PetSchema)],
   )
```