### PR TITLE
Add `CustomDeletable` and support for it in ResourceView

### DIFF
--- a/flask_crud/view.py
+++ b/flask_crud/view.py
@@ -158,6 +158,11 @@ class CollectionView(CRUDView):
         return query
 
 
+class CustomDeletable:
+    def perform_custom_deletion(self):
+        pass
+
+
 class ResourceView(CRUDView):
     get_enabled: bool = False
     update_enabled: bool = False
@@ -198,7 +203,10 @@ class ResourceView(CRUDView):
         item = self._lookup(pk)
         self._check_can_write(item)
 
-        self._db.session.delete(item)
+        if isinstance(item, CustomDeletable):
+            item.perform_custom_deletion()
+        else:
+            self._db.session.delete(item)
         self._db.session.commit()
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as f:
 
 NAME = "flask_crud"
 DESCRIPTION = "Reusable CRUD endpoints using flask-rest-api."
-VERSION = "0.0.2"
+VERSION = "0.0.3"
 REQUIRES_PYTHON = ">=3.6.0"
 
 setup(


### PR DESCRIPTION
`CustomDeletable` is used to alter behavior of `ResourceView.delete()` function. Main motivation is to make handling of `SoftDeletable` entities automatic.

Example use case:
```python
class SoftDeletable(CustomDeletable):
    """Model mixin."""

    deleted_on = Column(DateTime(timezone=True))

    def mark_deleted(self) -> None:
        self.deleted_on = func.now()

    def is_deleted(self) -> bool:
        return self.deleted_on is not None

    def perform_custom_deletion(self):    # this is defined by `CustomDeletable`
        self.mark_deleted()

```

`ResourceView.delete()` will detect that handled entity is `CustomDeletable` and will call `perform_custom_deletion()` instead of `session.delete()`.

Now every `delete` that looks like this
```python
@blp.response()
def delete(self, pk):
    user = User.query.get_or_404(pk)
    user.mark_deleted()
    db.session.commit()
```
...can be replaced with default
```python
@blp.response()
def delete(self, pk):
    return super().delete(pk)
```